### PR TITLE
Update list of repos

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,7 +38,6 @@ repos = [
     'alphagov/govuk-dns',
     'alphagov/govuk-docker',
     'alphagov/govuk-secrets',
-    'alphagov/govuk-puppet',
     'alphagov/govuk_publishing_components',
     'alphagov/govuk-saas-config',
     'alphagov/govuk-zendesk-display-screen',

--- a/main.py
+++ b/main.py
@@ -21,6 +21,8 @@ repos = [
     'alphagov/content-publisher',
     'alphagov/content-store',
     'alphagov/content-tagger',
+    'alphagov/datagovuk_find',
+    'alphagov/datagovuk_publish',
     'alphagov/email-alert-api',
     'alphagov/email-alert-frontend',
     'alphagov/email-alert-service',

--- a/main.py
+++ b/main.py
@@ -37,7 +37,6 @@ repos = [
     'alphagov/govuk-developer-docs',
     'alphagov/govuk-dns',
     'alphagov/govuk-docker',
-    'alphagov/govuk-lint',
     'alphagov/govuk-secrets',
     'alphagov/govuk-puppet',
     'alphagov/govuk_publishing_components',


### PR DESCRIPTION
- We no longer use alphagov/govuk-lint - it's archived.
- Add DGU Find and Publish, as we maintain those too.
- Don't try to upgrade the Ruby version in alphagov/govuk-puppet. See
  9daa2c7's commit message for more detail.